### PR TITLE
feat: validate dependency types in registry

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,11 @@ type ObjectLike = Record<string, unknown>;
  * All the dependencies of the declared injectables on a registry
  */
 export type FlatDependencyTree<Registry extends ObjectLike> =
-  UnionToIntersection<Dependencies<Registry[keyof Registry]>>;
+  UnionToIntersection<
+    {
+      [key in keyof Registry]: Dependencies<Registry[key]>;
+    }[keyof Registry]
+  >;
 
 /**
  * All the Injectables defined by a registry
@@ -78,12 +82,8 @@ export type ProviderFn<
 /**
  * Checks if each injectable match the required dependencies of the entire registry
  */
-type ValidateRegistry<Registry extends ObjectLike> = {
-  [K in keyof Registry]: K extends keyof FlatDependencyTree<Registry>
-    ? Injectable<Registry[K]> extends FlatDependencyTree<Registry>[K]
-      ? Registry[K] // -> fulfilled dependency
-      : never // -> unfulfilled dependency
-    : Registry[K]; // -> not a dependency
+type ValidateRegistry<Registry extends ObjectLike, Deps = FlatDependencyTree<Registry>> = {
+  [key in keyof Registry]: key extends keyof Deps ? ((deps?: any) => Deps[key]) | Deps[key] : Registry[key];
 };
 
 declare function valueFn<T>(value: T): () => T;

--- a/src/test.ts
+++ b/src/test.ts
@@ -203,30 +203,27 @@ createProvider: {
     },
   })({});
 
-  let someProvider = createProvider({
+  createProvider({
     injectables: {
-      a: ({ b }: { b: string }) => b,
-      b: () => 42,
+      foo: ({ a }: { a: number }) => a,
+      bar: ({ b }: { b: string }) => b,
+      // @ts-expect-error a is not a number
+      a: "42",
+      // @ts-expect-error b is not a string 
+      b: () => 42 as number,
     },
-    api: ['a'],
+    api: ['foo', 'bar'],
   });
 
-  // @ts-expect-error
-  // b is not a number
-  someProvider();
-
-  let f = createProvider({
+  createProvider({
     injectables: {
-      a: ({ b }: { b: number }) => b,
-      c: ({ b }: { b: string }) => b,
-      b: 42,
+      a: ({ c }: { c: number }) => c,
+      b: ({ c }: { c: string }) => c,
+      // @ts-expect-error c does not satisfy a & b
+      c: 42,
     },
-    api: ['a'],
+    api: ['a', 'c'],
   });
-
-  // @ts-expect-error
-  // b can not be fulfilled
-  f();
 
   // when all dependencies are provide, external Deps is optional
   const provideFulfilled = createProvider({
@@ -253,11 +250,20 @@ createProvider: {
   provideMissing();
   // @ts-expect-error
   provideMissing({});
+
+  const provideWrongType = createProvider({
+    injectables: {
+      foo: ({ val }: { val: number }) => val,
+    },
+    api: ['foo'],
+  });
+  // @ts-expect-error wrong dependency type
+  provideWrongType({ val: "42" })
 }
 
 fromClass: {
   class Foo {
-    constructor({ b }: { b: string }) {}
+    constructor({ b }: { b: string }) { }
   }
   let factory = fromClass(Foo);
   factory({ b: 'woot' });


### PR DESCRIPTION
When there are type conflicts on the injectables, we get only an error when providing the api.  

In this PR, we propose to typecheck the registry when creating moduleFactory. I don't see any reason (is there any ?) to inject a dependency with a different type than the one expected by other dependencies. That's why we should be able to get an error when instantiating a moduleFactory.
