### PR TITLE
feat(types): functions must be wrapped in functions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,7 +82,7 @@ export type ProviderFn<
 /**
  * If the injectable is a function, we have to wrap it in a function to avoid treating it as a factory
  */
-type WrapFunctionInjectable<T> = T extends (...args: any[]) => any 
+type WrapFunctionInjectable<T> = [T] extends [(...args: any[]) => any]
   ? (deps?: any) => T 
   : ((deps?: any) => T) | T;
   

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,7 @@
-type Function = (...args: any[]) => any;
 /**
  * Factory as defined in the injectable property: either a function with eventually a single named dependencies argument object or a value
  */
-export type FactoryFn<FactoryLike> = FactoryLike extends Function
+export type FactoryFn<FactoryLike> = FactoryLike extends (args: any) => any
   ? FactoryLike
   : () => FactoryLike;
 
@@ -81,23 +80,24 @@ export type ProviderFn<
   : (externalDeps: ProviderFnArgs<Registry>) => ModuleAPI<Registry, PublicAPI>;
 
 /**
- * When injecting an injectable, it can be wrapped in a function to inject some dependencies
- * However, if the injectable is a function, we have to wrap it in a function to avoid calling it early
+ * If the injectable is a function, we have to wrap it in a function to avoid treating it as a factory
  */
-type WrapInjectable<T> = T extends Function ? (deps?: any) => T : ((deps?: any) => T) | T;
+type WrapFunctionInjectable<T> = T extends (...args: any[]) => any 
+  ? (deps?: any) => T 
+  : ((deps?: any) => T) | T;
   
 /**
  * Checks if each injectable match the required dependencies of the entire registry
  */
-export type ValidateRegistry<Registry extends ObjectLike, Deps = FlatDependencyTree<Registry>> = {
-  [key in keyof Registry]: key extends keyof Deps ? WrapInjectable<Deps[key]> : Registry[key];
+type ValidateRegistry<Registry extends ObjectLike, Deps = FlatDependencyTree<Registry>> = {
+  [key in keyof Registry]: key extends keyof Deps ? WrapFunctionInjectable<Deps[key]> : Registry[key];
 };
 
 declare function valueFn<T>(value: T): () => T;
 
 declare const provideSymbol: unique symbol;
 
-declare function singleton<Factory extends Function>(
+declare function singleton<Factory extends (...args: any[]) => any>(
   factory: Factory
 ): (...args: Parameters<Factory>) => ReturnType<Factory>;
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -207,12 +207,15 @@ createProvider: {
     injectables: {
       foo: ({ a }: { a: number }) => a,
       bar: ({ b }: { b: string }) => b,
+      baz: ({ c }: { c: () => boolean }) => c(),
       // @ts-expect-error a is not a number
       a: "42",
       // @ts-expect-error b is not a string 
       b: () => 42 as number,
+      // @ts-expect-error c has to be wrapped in a function
+      c: () => true,
     },
-    api: ['foo', 'bar'],
+    api: ['foo', 'bar', 'baz'],
   });
 
   createProvider({

--- a/src/test.ts
+++ b/src/test.ts
@@ -5,6 +5,7 @@ import type {
   Injectable,
   InjectableMap,
   ProviderFn,
+  WrapFunctionInjectable,
 } from './index';
 import {
   createProvider,
@@ -176,6 +177,11 @@ lateBoundDependencies: {
     // @ts-expect-error
     x: 'hello',
   };
+}
+
+wrapFunctionInjectable: {
+  // test that () => SomeUnionType is assignable to WrapFunctionInjectable<SomeUnionType>
+  let unionInjectable: WrapFunctionInjectable<'a' | 'b'> = (): 'a' | 'b' => 'a';
 }
 
 publicAPI: {


### PR DESCRIPTION
When a provider require an injectable extending a function signature, this function needs to be wrapped by another function since the module will automatically call the former function to instanciate the injectable.  

Dependencies can be of type `T | (args?: any) => T`, we propose to narrow this type to only `(args?: any) => T` when T is a function.