### PR TITLE
fix: FlatDependencyTree type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,11 +31,7 @@ type ObjectLike = Record<string, unknown>;
  * All the dependencies of the declared injectables on a registry
  */
 export type FlatDependencyTree<Registry extends ObjectLike> =
-  UnionToIntersection<
-    {
-      [key in keyof Registry]: Dependencies<Registry[key]>;
-    }[keyof Registry]
-  >;
+  UnionToIntersection<Dependencies<Registry[keyof Registry]>>;
 
 /**
  * All the Injectables defined by a registry

--- a/src/test.ts
+++ b/src/test.ts
@@ -260,6 +260,20 @@ createProvider: {
   // @ts-expect-error
   provideMissing({});
 
+  const provideDeepMissing = createProvider({
+    injectables: {
+      foo: ({ service }: { service: number }) => service,
+      service: ({ nonTypedDep }) => nonTypedDep,
+      bar: ({ typedDep }: { typedDep: string }) => typedDep,
+    },
+    api: ['foo', 'bar'],
+  });
+  provideDeepMissing({ typedDep: 'toto', nonTypedDep: 42 });
+  // @ts-expect-error typedDep & nonTypedDep is missing here
+  provideDeepMissing();
+ // @ts-expect-error typedDep & nonTypedDep is missing here
+  provideDeepMissing({});
+
   const provideWrongType = createProvider({
     injectables: {
       foo: ({ val }: { val: number }) => val,


### PR DESCRIPTION
Hi,
I noticed a regression in the external dependencies type introduced by #6.

Here is a minimal repro
```typescript
const provide = createProvider({
  injectables: {
    foo: ({ service }: { service: number }) => service,
    service: ({ nonTypedDep }) => nonTypedDep,
  },
  api: ['foo'],
});
provide()
```

This behavior propagates to other external dependencies which won't be required.
